### PR TITLE
Configure action mailer with SMTP config details

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,6 +62,17 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch('MAILGUN_SMTP_SERVER'),
+    port: ENV.fetch('MAILGUN_SMTP_PORT'),
+    domain: 'tranquil-citadel-81495.herokuapp.com',
+    user_name: ENV.fetch('MAILGUN_SMTP_LOGIN'),
+    password: ENV.fetch('MAILGUN_SMTP_PASSWORD'),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
We added Mailgun's Heroku addon with a free plan to start with and so these ENV vars are already provisioned.