### PR TITLE
Add and configure Sidekiq

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'spree_gateway', '~> 3.9'
 
 gem 'pg', '~> 1.2', '>= 1.2.3'
 
+gem 'sidekiq'
+
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     childprocess (3.0.0)
     cldr-plurals-runtime-rb (1.1.0)
     concurrent-ruby (1.1.7)
+    connection_pool (2.2.3)
     crass (1.0.6)
     css_parser (1.7.1)
       addressable
@@ -240,6 +241,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.5)
     regexp_parser (1.8.2)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -262,6 +264,10 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sidekiq (6.1.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     spree (4.1.12)
       spree_api (= 4.1.12)
       spree_backend (= 4.1.12)
@@ -400,6 +406,7 @@ DEPENDENCIES
   rails (~> 6.0.3, >= 6.0.3.4)
   sass-rails (>= 6)
   selenium-webdriver
+  sidekiq
   spree (~> 4.1)
   spree_auth_devise (~> 4.2)
   spree_gateway (~> 3.9)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 release: bundle exec rails db:migrate
+worker: bundle exec sidekiq -c 5


### PR DESCRIPTION
I chose 5 threads for concurrency so we stay within the limit of 20 DB connections in Heroku's hobby-free plan. We have to count the 5 threads of each of the two Puma workers plus this 5 from the Sidekiq worker = 15, which gives us room to open connections with psql, for instance.