### PR TITLE
Enable ActiveJob's Sidekiq adapter

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: bundle exec rails db:migrate
-worker: bundle exec sidekiq -c 5
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -57,7 +57,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  config.active_job.queue_adapter     = :sidekiq
   # config.active_job.queue_name_prefix = "la_zona_production"
 
   config.action_mailer.perform_caching = false

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,3 +2,4 @@
 :queues:
 - default
 - mailers
+- active_storage_analysis

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,4 @@
+:concurrency: 5
+:queues:
+- default
+- mailers


### PR DESCRIPTION
By doing so we need to tell Sidekiq to process both the default and the mailers queues. That's because Rails enqueues mailers in that queue. Spree supports that default behaviour. See: https://github.com/spree/spree/blob/master/guides/src/content/release_notes/3_0_0.md#rails-42-support.