### PR TITLE
Setup Spree multi vendor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,11 @@ ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
+
 gem 'spree', '~> 4.1'
 gem 'spree_auth_devise', '~> 4.2'
 gem 'spree_gateway', '~> 3.9'
+gem 'spree_multi_vendor', github: 'spree-contrib/spree_multi_vendor'
 
 gem 'pg', '~> 1.2', '>= 1.2.3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/spree-contrib/spree_multi_vendor.git
+  revision: 9cdba236f59d3a20f26ccb1f5bf5e0adf6e008b0
+  specs:
+    spree_multi_vendor (1.5.3)
+      deface (~> 1.0)
+      spree_backend (>= 3.7.0, < 5.0)
+      spree_core (>= 3.7.0, < 5.0)
+      spree_extension
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -415,6 +425,7 @@ DEPENDENCIES
   spree (~> 4.1)
   spree_auth_devise (~> 4.2)
   spree_gateway (~> 3.9)
+  spree_multi_vendor!
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/db/migrate/20201202145303_create_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145303_create_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,10 @@
+# This migration comes from spree_multi_vendor (originally 20170406102250)
+class CreateSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_vendors do |t|
+      t.string :name
+      t.timestamps
+    end
+    add_index :spree_vendors, :name, unique: true
+  end
+end

--- a/db/migrate/20201202145304_add_vendor_id_to_spree_models.spree_multi_vendor.rb
+++ b/db/migrate/20201202145304_add_vendor_id_to_spree_models.spree_multi_vendor.rb
@@ -1,0 +1,17 @@
+# This migration comes from spree_multi_vendor (originally 20170406102944)
+class AddVendorIdToSpreeModels < SpreeExtension::Migration[4.2]
+  def change
+    table_names = %w[
+      option_types
+      properties
+      products
+      stock_locations
+      shipping_methods
+      variants
+    ]
+
+    table_names.each do |table_name|
+      add_reference "spree_#{table_name}", :vendor, index: true
+    end
+  end
+end

--- a/db/migrate/20201202145305_add_state_to_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145305_add_state_to_vendors.spree_multi_vendor.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_multi_vendor (originally 20170410111150)
+class AddStateToVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :state, :string
+    add_index :spree_vendors, :state
+  end
+end

--- a/db/migrate/20201202145306_add_deleted_at_to_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145306_add_deleted_at_to_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_multi_vendor (originally 20170412124925)
+class AddDeletedAtToSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :deleted_at, :datetime
+    add_index :spree_vendors, :deleted_at
+  end
+end

--- a/db/migrate/20201202145307_create_spree_vendor_users.spree_multi_vendor.rb
+++ b/db/migrate/20201202145307_create_spree_vendor_users.spree_multi_vendor.rb
@@ -1,0 +1,12 @@
+# This migration comes from spree_multi_vendor (originally 20170413094447)
+class CreateSpreeVendorUsers < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_vendor_users do |t|
+      t.references :vendor
+      t.references :user
+    end
+    add_index :spree_vendor_users, [:vendor_id, :user_id], unique: true
+    add_index :spree_vendor_users, :vendor_id
+    add_index :spree_vendor_users, :user_id
+  end
+end

--- a/db/migrate/20201202145308_add_slug_to_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145308_add_slug_to_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,7 @@
+# This migration comes from spree_multi_vendor (originally 20190212161426)
+class AddSlugToSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :slug, :string
+    add_index :spree_vendors, :slug, unique: true
+  end
+end

--- a/db/migrate/20201202145309_add_about_us_to_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145309_add_about_us_to_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_multi_vendor (originally 20190214120226)
+class AddAboutUsToSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :about_us, :text
+  end
+end

--- a/db/migrate/20201202145310_add_contact_us_to_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145310_add_contact_us_to_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_multi_vendor (originally 20190214142526)
+class AddContactUsToSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :contact_us, :text
+  end
+end

--- a/db/migrate/20201202145311_add_commission_to_spree_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145311_add_commission_to_spree_vendors.spree_multi_vendor.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_multi_vendor (originally 20190305120337)
+class AddCommissionToSpreeVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :commission_rate, :float, default: '5.0'
+  end
+end

--- a/db/migrate/20201202145312_add_priority_to_vendor.spree_multi_vendor.rb
+++ b/db/migrate/20201202145312_add_priority_to_vendor.spree_multi_vendor.rb
@@ -1,0 +1,9 @@
+# This migration comes from spree_multi_vendor (originally 20190308091546)
+class AddPriorityToVendor < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :priority, :integer
+    Spree::Vendor.order(:updated_at).each.with_index(1) do |vendor, index|
+      vendor.update_column :priority, index
+    end
+  end
+end

--- a/db/migrate/20201202145313_create_spree_order_commissions.spree_multi_vendor.rb
+++ b/db/migrate/20201202145313_create_spree_order_commissions.spree_multi_vendor.rb
@@ -1,0 +1,15 @@
+# This migration comes from spree_multi_vendor (originally 20190312130754)
+class CreateSpreeOrderCommissions < SpreeExtension::Migration[4.2]
+  def change
+    create_table :spree_order_commissions do |t|
+      t.references :order
+      t.references :vendor
+      t.float :amount
+
+      t.timestamps
+    end
+    add_index :spree_order_commissions, [:order_id, :vendor_id], unique: true
+    add_index :spree_order_commissions, :order_id
+    add_index :spree_order_commissions, :vendor_id
+  end
+end

--- a/db/migrate/20201202145314_add_notification_email_to_vendors.spree_multi_vendor.rb
+++ b/db/migrate/20201202145314_add_notification_email_to_vendors.spree_multi_vendor.rb
@@ -1,0 +1,6 @@
+# This migration comes from spree_multi_vendor (originally 20190322133128)
+class AddNotificationEmailToVendors < SpreeExtension::Migration[4.2]
+  def change
+    add_column :spree_vendors, :notification_email, :string
+  end
+end

--- a/db/migrate/20201202145315_add_translations_to_vendor.spree_multi_vendor.rb
+++ b/db/migrate/20201202145315_add_translations_to_vendor.spree_multi_vendor.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+# This migration comes from spree_multi_vendor (originally 20200416030721)
+
+# Based on issue https://github.com/spree-contrib/spree_multi_vendor/issues/104
+# This is a patch for Spree globalize to be friendly with the gem
+
+class AddTranslationsToVendor < ActiveRecord::Migration[4.2]
+  def up
+    params = { name: :string, about_us: :text, contact_us: :text, slug: :string }
+    if defined?(SpreeGlobalize)
+      Spree::Vendor.create_translation_table!(params, { migrate_data: true })
+    end
+  end
+
+  def down
+    if defined?(SpreeGlobalize)
+      Spree::Vendor.drop_translation_table! migrate_data: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_01_092946) do
+ActiveRecord::Schema.define(version: 2020_12_02_145315) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "action_mailbox_inbound_emails", force: :cascade do |t|
     t.integer "status", default: 0, null: false
@@ -171,8 +174,8 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.boolean "states_required", default: false
     t.datetime "updated_at"
     t.boolean "zipcode_required", default: true
-    t.index "(lower(iso_name))", name: "index_spree_countries_on_lower_iso_name", unique: true
-    t.index "(lower(name))", name: "index_spree_countries_on_lower_name", unique: true
+    t.index "lower((iso_name)::text)", name: "index_spree_countries_on_lower_iso_name", unique: true
+    t.index "lower((name)::text)", name: "index_spree_countries_on_lower_name", unique: true
     t.index ["iso"], name: "index_spree_countries_on_iso", unique: true
     t.index ["iso3"], name: "index_spree_countries_on_iso3", unique: true
   end
@@ -326,8 +329,10 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.integer "position", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "vendor_id"
     t.index ["name"], name: "index_spree_option_types_on_name"
     t.index ["position"], name: "index_spree_option_types_on_position"
+    t.index ["vendor_id"], name: "index_spree_option_types_on_vendor_id"
   end
 
   create_table "spree_option_value_variants", force: :cascade do |t|
@@ -348,6 +353,17 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.index ["name"], name: "index_spree_option_values_on_name"
     t.index ["option_type_id"], name: "index_spree_option_values_on_option_type_id"
     t.index ["position"], name: "index_spree_option_values_on_position"
+  end
+
+  create_table "spree_order_commissions", id: :serial, force: :cascade do |t|
+    t.integer "order_id"
+    t.integer "vendor_id"
+    t.float "amount"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["order_id", "vendor_id"], name: "index_spree_order_commissions_on_order_id_and_vendor_id", unique: true
+    t.index ["order_id"], name: "index_spree_order_commissions_on_order_id"
+    t.index ["vendor_id"], name: "index_spree_order_commissions_on_vendor_id"
   end
 
   create_table "spree_order_promotions", force: :cascade do |t|
@@ -521,6 +537,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.boolean "promotionable", default: true
     t.string "meta_title"
     t.datetime "discontinue_on"
+    t.integer "vendor_id"
     t.index ["available_on"], name: "index_spree_products_on_available_on"
     t.index ["deleted_at"], name: "index_spree_products_on_deleted_at"
     t.index ["discontinue_on"], name: "index_spree_products_on_discontinue_on"
@@ -528,6 +545,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.index ["shipping_category_id"], name: "index_spree_products_on_shipping_category_id"
     t.index ["slug"], name: "index_spree_products_on_slug", unique: true
     t.index ["tax_category_id"], name: "index_spree_products_on_tax_category_id"
+    t.index ["vendor_id"], name: "index_spree_products_on_vendor_id"
   end
 
   create_table "spree_products_taxons", force: :cascade do |t|
@@ -619,7 +637,9 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.string "presentation", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "vendor_id"
     t.index ["name"], name: "index_spree_properties_on_name"
+    t.index ["vendor_id"], name: "index_spree_properties_on_vendor_id"
   end
 
   create_table "spree_property_prototypes", force: :cascade do |t|
@@ -650,7 +670,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.boolean "mutable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index "(lower(name))", name: "index_spree_refund_reasons_on_lower_name", unique: true
+    t.index "lower((name)::text)", name: "index_spree_refund_reasons_on_lower_name", unique: true
   end
 
   create_table "spree_refunds", force: :cascade do |t|
@@ -682,7 +702,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "type"
-    t.index "(lower(name))", name: "index_spree_reimbursement_types_on_lower_name", unique: true
+    t.index "lower((name)::text)", name: "index_spree_reimbursement_types_on_lower_name", unique: true
     t.index ["type"], name: "index_spree_reimbursement_types_on_type"
   end
 
@@ -705,7 +725,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.boolean "mutable", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index "(lower(name))", name: "index_spree_return_authorization_reasons_on_lower_name", unique: true
+    t.index "lower((name)::text)", name: "index_spree_return_authorization_reasons_on_lower_name", unique: true
   end
 
   create_table "spree_return_authorizations", force: :cascade do |t|
@@ -758,7 +778,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
 
   create_table "spree_roles", force: :cascade do |t|
     t.string "name"
-    t.index "(lower(name))", name: "index_spree_roles_on_lower_name", unique: true
+    t.index "lower((name)::text)", name: "index_spree_roles_on_lower_name", unique: true
   end
 
   create_table "spree_shipments", force: :cascade do |t|
@@ -819,8 +839,10 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.string "admin_name"
     t.integer "tax_category_id"
     t.string "code"
+    t.integer "vendor_id"
     t.index ["deleted_at"], name: "index_spree_shipping_methods_on_deleted_at"
     t.index ["tax_category_id"], name: "index_spree_shipping_methods_on_tax_category_id"
+    t.index ["vendor_id"], name: "index_spree_shipping_methods_on_vendor_id"
   end
 
   create_table "spree_shipping_rates", force: :cascade do |t|
@@ -890,11 +912,13 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.boolean "backorderable_default", default: false
     t.boolean "propagate_all_variants", default: true
     t.string "admin_name"
+    t.integer "vendor_id"
     t.index ["active"], name: "index_spree_stock_locations_on_active"
     t.index ["backorderable_default"], name: "index_spree_stock_locations_on_backorderable_default"
     t.index ["country_id"], name: "index_spree_stock_locations_on_country_id"
     t.index ["propagate_all_variants"], name: "index_spree_stock_locations_on_propagate_all_variants"
     t.index ["state_id"], name: "index_spree_stock_locations_on_state_id"
+    t.index ["vendor_id"], name: "index_spree_stock_locations_on_vendor_id"
   end
 
   create_table "spree_stock_movements", force: :cascade do |t|
@@ -987,7 +1011,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.string "facebook"
     t.string "twitter"
     t.string "instagram"
-    t.index "(lower(code))", name: "index_spree_stores_on_lower_code", unique: true
+    t.index "lower((code)::text)", name: "index_spree_stores_on_lower_code", unique: true
     t.index ["default"], name: "index_spree_stores_on_default"
     t.index ["url"], name: "index_spree_stores_on_url"
   end
@@ -1117,6 +1141,7 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.datetime "updated_at", null: false
     t.datetime "discontinue_on"
     t.datetime "created_at", null: false
+    t.integer "vendor_id"
     t.index ["deleted_at"], name: "index_spree_variants_on_deleted_at"
     t.index ["discontinue_on"], name: "index_spree_variants_on_discontinue_on"
     t.index ["is_master"], name: "index_spree_variants_on_is_master"
@@ -1125,6 +1150,33 @@ ActiveRecord::Schema.define(version: 2020_12_01_092946) do
     t.index ["sku"], name: "index_spree_variants_on_sku"
     t.index ["tax_category_id"], name: "index_spree_variants_on_tax_category_id"
     t.index ["track_inventory"], name: "index_spree_variants_on_track_inventory"
+    t.index ["vendor_id"], name: "index_spree_variants_on_vendor_id"
+  end
+
+  create_table "spree_vendor_users", id: :serial, force: :cascade do |t|
+    t.integer "vendor_id"
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_spree_vendor_users_on_user_id"
+    t.index ["vendor_id", "user_id"], name: "index_spree_vendor_users_on_vendor_id_and_user_id", unique: true
+    t.index ["vendor_id"], name: "index_spree_vendor_users_on_vendor_id"
+  end
+
+  create_table "spree_vendors", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.string "state"
+    t.datetime "deleted_at"
+    t.string "slug"
+    t.text "about_us"
+    t.text "contact_us"
+    t.float "commission_rate", default: 5.0
+    t.integer "priority"
+    t.string "notification_email"
+    t.index ["deleted_at"], name: "index_spree_vendors_on_deleted_at"
+    t.index ["name"], name: "index_spree_vendors_on_name", unique: true
+    t.index ["slug"], name: "index_spree_vendors_on_slug", unique: true
+    t.index ["state"], name: "index_spree_vendors_on_state"
   end
 
   create_table "spree_zone_members", force: :cascade do |t|


### PR DESCRIPTION
This extension is meant to enable Spree as a multi vendor marketplace. See: https://github.com/spree-contrib/spree_multi_vendor.