### PR TITLE
Set Cache-Control header for object storage files

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -15,6 +15,8 @@ backblaze:
   access_key_id: <%= ENV["B2_ACCESS_KEY_ID"] %>
   secret_access_key: <%= ENV["B2_SECRET_ACCESS_KEY"] %>
   bucket: <%= ENV["B2_BUCKET_NAME"] %>
+  upload:
+    cache_control: <%= "max-age=#{365.day.to_i}" %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
We want browsers to cache assets after the first fetch to save network round trips.